### PR TITLE
Added missing imports so that tests pass with a correct solution with…

### DIFF
--- a/src/test/kotlin/chapter5/exercises/Exercise_5_10.kt
+++ b/src/test/kotlin/chapter5/exercises/Exercise_5_10.kt
@@ -3,6 +3,7 @@ package chapter5.exercises
 import chapter3.List
 import chapter5.Stream
 import chapter5.solutions.toList
+import chapter5.solutions.take
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
 

--- a/src/test/kotlin/chapter5/exercises/Exercise_5_11.kt
+++ b/src/test/kotlin/chapter5/exercises/Exercise_5_11.kt
@@ -3,7 +3,10 @@ package chapter5.exercises
 import chapter3.List
 import chapter4.Option
 import chapter4.Some
+import chapter4.solutions.getOrElse
+import chapter4.solutions.map
 import chapter5.Stream
+import chapter5.solutions.take
 import chapter5.solutions.toList
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec

--- a/src/test/kotlin/chapter5/exercises/Exercise_5_12.kt
+++ b/src/test/kotlin/chapter5/exercises/Exercise_5_12.kt
@@ -2,6 +2,7 @@ package chapter5.exercises
 
 import chapter3.List
 import chapter5.Stream
+import chapter5.solutions.take
 import chapter5.solutions.toList
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec

--- a/src/test/kotlin/chapter5/exercises/Exercise_5_8.kt
+++ b/src/test/kotlin/chapter5/exercises/Exercise_5_8.kt
@@ -3,6 +3,7 @@ package chapter5.exercises
 import chapter3.List
 import chapter5.Stream
 import chapter5.solutions.toList
+import chapter5.solutions.take
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
 

--- a/src/test/kotlin/chapter5/exercises/Exercise_5_9.kt
+++ b/src/test/kotlin/chapter5/exercises/Exercise_5_9.kt
@@ -3,6 +3,7 @@ package chapter5.exercises
 import chapter3.List
 import chapter5.Stream
 import chapter5.solutions.toList
+import chapter5.solutions.take
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
 


### PR DESCRIPTION
…out depending on future exercises

For example, the take() function is defined and worked on in exercise 5.13. If I don't add the import referring to the "solutions" version of take() in exercises prior to 5.13, then the take() they will refer to is the one in Exercise_5_13.kt, which is likely not to have been solved yet while the reader works on earlier exercises.

The builds will therefore fail with a NotImplementedError caused by that function not having been implemented yet.

These extra imports are not necessary in the solutions since the take() version they refer to is that of Solution_5_13.kt, which contains a solved version of take().