### PR TITLE
Chapter11: adding return types in map2 methods

### DIFF
--- a/src/main/kotlin/chapter11/sec2/listing.kt
+++ b/src/main/kotlin/chapter11/sec2/listing.kt
@@ -87,7 +87,7 @@ interface Monad<F> : Functor<F> { // <1>
         fa: Kind<F, A>,
         fb: Kind<F, B>,
         f: (A, B) -> C
-    ) =
+    ): Kind<F, C> =
         flatMap(fa) { a -> map(fb) { b -> f(a, b) } }
 }
 //end::init7[]

--- a/src/main/kotlin/chapter11/sec3/listing.kt
+++ b/src/main/kotlin/chapter11/sec3/listing.kt
@@ -11,7 +11,11 @@ interface Monad<F> : Functor<F> {
     override fun <A, B> map(fa: Kind<F, A>, f: (A) -> B): Kind<F, B> =
         flatMap(fa) { a -> unit(f(a)) }
 
-    fun <A, B, C> map2(fa: Kind<F, A>, fb: Kind<F, B>, f: (A, B) -> C) =
+    fun <A, B, C> map2(
+        fa: Kind<F, A>,
+        fb: Kind<F, B>,
+        f: (A, B) -> C
+    ): Kind<F, C> =
         flatMap(fa) { a -> map(fb) { b -> f(a, b) } }
 
     //tag::init[]

--- a/src/test/kotlin/chapter11/solutions/ex3/listing.kt
+++ b/src/test/kotlin/chapter11/solutions/ex3/listing.kt
@@ -13,7 +13,11 @@ interface Monad<F> : Functor<F> {
     override fun <A, B> map(fa: Kind<F, A>, f: (A) -> B): Kind<F, B> =
         flatMap(fa) { a -> unit(f(a)) }
 
-    fun <A, B, C> map2(fa: Kind<F, A>, fb: Kind<F, B>, f: (A, B) -> C) =
+    fun <A, B, C> map2(
+        fa: Kind<F, A>,
+        fb: Kind<F, B>,
+        f: (A, B) -> C
+    ): Kind<F, C> =
         flatMap(fa) { a -> map(fb) { b -> f(a, b) } }
 
     //tag::traverse[]

--- a/src/test/kotlin/chapter11/solutions/ex4/listing.kt
+++ b/src/test/kotlin/chapter11/solutions/ex4/listing.kt
@@ -13,7 +13,11 @@ interface Monad<F> : Functor<F> {
     override fun <A, B> map(fa: Kind<F, A>, f: (A) -> B): Kind<F, B> =
         flatMap(fa) { a -> unit(f(a)) }
 
-    fun <A, B, C> map2(fa: Kind<F, A>, fb: Kind<F, B>, f: (A, B) -> C) =
+    fun <A, B, C> map2(
+        fa: Kind<F, A>,
+        fb: Kind<F, B>,
+        f: (A, B) -> C
+    ): Kind<F, C> =
         flatMap(fa) { a -> map(fb) { b -> f(a, b) } }
 
     fun <A> sequence(lfa: List<Kind<F, A>>): Kind<F, List<A>> =


### PR DESCRIPTION
There are some methods `map2` in the chapter 11 without return type. For readability I think is a good practise to add them.