### PR TITLE
Gen#choose should select within specified range

### DIFF
--- a/src/main/kotlin/chapter8/sec3/listing3/listing.kt
+++ b/src/main/kotlin/chapter8/sec3/listing3/listing.kt
@@ -19,7 +19,7 @@ data class Gen<A>(val sample: State<RNG, A>) {
 
         fun choose(start: Int, stopExclusive: Int): Gen<Int> =
             Gen(State { rng: RNG -> nonNegativeInt(rng) }
-                .map { (start + it) % (stopExclusive - start) })
+                .map { start + (it % (stopExclusive - start)) })
 
         fun <A> listOfN(n: Int, ga: Gen<A>): Gen<List<A>> =
             Gen(State.sequence(List(n) { ga.sample }))


### PR DESCRIPTION
This fix causes choose to select within the specified range, not
within the difference of the specified range.
For example if start = 5 and stopExclusive = 10, the fix returns
numbers from [5, 10), not from [0, 5).