### PR TITLE
Make Gen<A>#choose no less uniformly distributed than RNG

### DIFF
--- a/src/main/kotlin/chapter8/sec3/listing3/listing.kt
+++ b/src/main/kotlin/chapter8/sec3/listing3/listing.kt
@@ -9,7 +9,6 @@ import chapter8.Result
 import chapter8.State
 import chapter8.TestCases
 import chapter8.double
-import chapter8.nonNegativeInt
 import kotlin.math.absoluteValue
 import kotlin.math.min
 
@@ -18,8 +17,8 @@ data class Gen<A>(val sample: State<RNG, A>) {
         fun <A> unit(a: A): Gen<A> = Gen(State.unit(a))
 
         fun choose(start: Int, stopExclusive: Int): Gen<Int> =
-            Gen(State { rng: RNG -> nonNegativeInt(rng) }
-                .map { start + (it % (stopExclusive - start)) })
+            Gen(State { rng: RNG -> double(rng) }
+                .map { start + (it * (stopExclusive - start)).toInt() })
 
         fun <A> listOfN(n: Int, ga: Gen<A>): Gen<List<A>> =
             Gen(State.sequence(List(n) { ga.sample }))


### PR DESCRIPTION
Hey @marc0der!

I think this addresses the problem I raised in issue #25 .

To recap: The range produced by `nonNegativeInt` may not be an exact multiple of the range on the right side of the mod operator.  This will introduce bias into random generation.

For example: If we simplify things and say that the total range produced by `nonNegativeInt` is `0-3` and the range on the right side of the mod is 3, we'll end up with 3 buckets: [0,3], [1], [2].  The 3 buckets represent randomly generated numbers 0-2.  But there are 2 ways to get the first bucket (0 or 3), while there is only 1 way each for the second and third buckets.  In other words there is 50% likelihood to get the first bucket, but 25% likelihood for the second and third buckets.  With uniform distribution we would expect 33% likelihood for any bucket.  I believe using `double` fixes this.