### PR TITLE
Improve takeWhile implementation

### DIFF
--- a/src/test/kotlin/chapter5/exercises/Exercise_5_5.kt
+++ b/src/test/kotlin/chapter5/exercises/Exercise_5_5.kt
@@ -17,9 +17,9 @@ class Exercise_5_5 : WordSpec({
 
     "Stream.takeWhile" should {
         "!return elements while the predicate evaluates true" {
-            val s = Stream.of(1, 2, 3, 4, 5)
+            val s = Stream.of(1, 2, 7, 3, 4, 5)
             s.takeWhile { it < 4 }.toList() shouldBe
-                List.of(1, 2, 3)
+                List.of(1, 2)
         }
         "!return all elements if predicate always evaluates true" {
             val s = Stream.of(1, 2, 3, 4, 5)

--- a/src/test/kotlin/chapter5/solutions/Solution_5_5.kt
+++ b/src/test/kotlin/chapter5/solutions/Solution_5_5.kt
@@ -13,14 +13,16 @@ class Solution_5_5 : WordSpec({
     //tag::init[]
     fun <A> Stream<A>.takeWhile(p: (A) -> Boolean): Stream<A> =
         foldRight({ empty() },
-            { h, t -> if (p(h)) cons({ h }, t) else t() })
+            { h, t ->
+                if (p(h)) cons({ h }, t) else { empty() }
+            })
     //end::init[]
 
     "Stream.takeWhile" should {
         "return elements while the predicate evaluates true" {
-            val s = Stream.of(1, 2, 3, 4, 5)
+            val s = Stream.of(1, 2, 7, 3, 4, 5)
             s.takeWhile { it < 4 }.toList() shouldBe
-                List.of(1, 2, 3)
+                List.of(1, 2)
         }
         "return all elements if predicate always evaluates true" {
             val s = Stream.of(1, 2, 3, 4, 5)


### PR DESCRIPTION
This will change the implementation of takeWhile and make it differ from
filter as the current implementation is equal to the filter
implementation. As of my understanding takeWhile should stop taking item
from the stream right after the predicate failed the first time.