### PR TITLE
Tech review ch15

### DIFF
--- a/src/main/kotlin/chapter15/sec2/listing.kt
+++ b/src/main/kotlin/chapter15/sec2/listing.kt
@@ -250,6 +250,7 @@ fun main() {
 
     //repeated left
     val units = Stream.continually(Unit)
+    println(units)
     println(lift<Unit, Int> { _ -> 1 }(units))
 
     //filtering

--- a/src/main/kotlin/chapter15/sec3_4/listing.kt
+++ b/src/main/kotlin/chapter15/sec3_4/listing.kt
@@ -110,7 +110,7 @@ fun <F, I1, I2, O> tee(
                 .onComplete { p2.kill() }
                 .onComplete { Halt(t.err) }
         is Emit ->
-            Emit(t.head, tee(p1, p2, t)) // <2>
+            Emit(t.head, tee(p1, p2, t.tail)) // <2>
         is Await<*, *, *> -> {
 
             val side = t.req as T<I1, I2, O>

--- a/src/main/kotlin/chapter15/sec3_5/listing.kt
+++ b/src/main/kotlin/chapter15/sec3_5/listing.kt
@@ -44,7 +44,10 @@ fun fileW(file: String, append: Boolean = false): Sink<ForIO, String> =
     resource(
         acquire = IO { FileWriter(file, append) }, // <1>
         use = { fw: FileWriter ->
-            constant { s: String -> eval(IO { fw.write(s) }) } // <2>
+            constant { s: String -> eval(IO {
+                fw.write(s)
+                fw.flush()
+            }) } // <2>
         },
         release = { fw: FileWriter ->
             evalDrain(IO { fw.close() }) // <3>
@@ -114,6 +117,7 @@ fun <I> intersperse(sep: I): Process1<I, I> =
         }
     })
 
+/*
 //tag::init4[]
 val converter: Process<ForIO, Unit> =
     lines("fahrenheit.txt")
@@ -123,6 +127,16 @@ val converter: Process<ForIO, Unit> =
         .to(fileW("celsius.txt"))
         .drain()
 //end::init4[]
+*/
+
+// Version with working paths
+val converter: Process<ForIO, Unit> =
+    lines("src/main/resources/fahrenheit.txt")
+        .filter { !it.startsWith("#") }
+        .map { line -> fahrenheitToCelsius(line.toDouble()).toString() }
+        .pipe(intersperse("\n"))
+        .to(fileW("build/celsius.txt"))
+        .drain()
 
 fun <A> unsafePerformIO(
     ioa: IOOf<A>,

--- a/src/main/kotlin/chapter15/sec3_7/listing.kt
+++ b/src/main/kotlin/chapter15/sec3_7/listing.kt
@@ -10,8 +10,8 @@ fun fahrenheitToCelsius(f: Double): Double = (f - 32) * 5.0 / 9.0
 
 //tag::init1[]
 val convertAll: Process<ForIO, Unit> =
-    fileW("celsius.tx").take(1).flatMap { out ->
-        lines("fahrenheits.txt")
+    fileW("celsius.txt").take(1).flatMap { out ->
+        lines("fahrenheit.txt")
             .flatMap { infile ->
                 lines(infile)
                     .map { fahrenheitToCelsius(it.toDouble()) }
@@ -22,7 +22,7 @@ val convertAll: Process<ForIO, Unit> =
 
 //tag::init2[]
 val convertMultiSink: Process<ForIO, Unit> =
-    lines("fahrenheits.txt")
+    lines("fahrenheit.txt")
         .flatMap { infile ->
             lines(infile)
                 .map { fahrenheitToCelsius(it.toDouble()) }
@@ -33,7 +33,7 @@ val convertMultiSink: Process<ForIO, Unit> =
 
 //tag::init3[]
 val convertMultisink2: Process<ForIO, Unit> =
-    lines("fahrenheits.txt").flatMap { infile ->
+    lines("fahrenheit.txt").flatMap { infile ->
         lines(infile)
             .filter { !it.startsWith("#") }
             .map { fahrenheitToCelsius(it.toDouble()) }

--- a/src/main/resources/fahrenheit.txt
+++ b/src/main/resources/fahrenheit.txt
@@ -1,0 +1,10 @@
+# Absolute zero
+-273.15
+# Water melting point
+32.0
+50.0
+68.0
+# Standard body temperature
+98.6
+# Water boiling point
+212.0

--- a/src/test/kotlin/chapter15/exercises/ex3/listing.kt
+++ b/src/test/kotlin/chapter15/exercises/ex3/listing.kt
@@ -19,7 +19,7 @@ fun mean(): Process<Double, Double> = TODO()
 
 class Exercise3 : WordSpec({
     "mean" should {
-        "!calculate a running average of values encounterd so far" {
+        "!calculate a running average of values encountered so far" {
             val stream = Stream.of(1.0, 2.0, 3.0, 4.0, 5.0)
             val p = mean()
             p(stream).toList() shouldBe List.of(1.0, 1.5, 2.0, 2.5, 3.0)

--- a/src/test/kotlin/chapter15/exercises/ex6/listing.kt
+++ b/src/test/kotlin/chapter15/exercises/ex6/listing.kt
@@ -41,7 +41,7 @@ class Exercise6 : WordSpec({
     }
 
     "mean" should {
-        "!calculate a running average of values encounterd so far" {
+        "!calculate a running average of values encountered so far" {
             val p = mean()
             p(stream).toList() shouldBe
                 List.of(1.0, 1.5, 2.0, 2.5, 3.0, 3.5)

--- a/src/test/kotlin/chapter15/solutions/ex1/listing.kt
+++ b/src/test/kotlin/chapter15/solutions/ex1/listing.kt
@@ -49,14 +49,14 @@ fun <I> dropWhile(p: (I) -> Boolean): Process<I, I> =
         when (i) {
             is Some ->
                 if (p(i.get)) dropWhile(p)
-                else Emit(i.get)
+                else Emit(i.get, dropWhile { false })
             is None -> Halt()
         }
     }.repeat()
 //end::init[]
 
 class Exercise1 : WordSpec({
-    val stream = Stream.of(1, 2, 3, 4, 5, 6, 7)
+    val stream = Stream.of(1, 2, 3, 4, 5, 6, 7, 1)
     "take" should {
         "consume the given number of elements from a stream" {
             take<Int>(5)(stream).toList() shouldBe List.of(1, 2, 3, 4, 5)
@@ -64,7 +64,7 @@ class Exercise1 : WordSpec({
     }
     "drop" should {
         "drop the given number of elements from a stream" {
-            drop<Int>(5)(stream).toList() shouldBe List.of(6, 7)
+            drop<Int>(5)(stream).toList() shouldBe List.of(6, 7, 1)
         }
     }
     "takeWhile" should {
@@ -76,7 +76,7 @@ class Exercise1 : WordSpec({
     "dropWhile" should {
         "drop elements from a stream while a predicate is true" {
             dropWhile<Int> { 5 > it }(stream).toList() shouldBe
-                List.of(5, 6, 7)
+                List.of(5, 6, 7, 1)
         }
     }
 })

--- a/src/test/kotlin/chapter15/solutions/ex3/listing.kt
+++ b/src/test/kotlin/chapter15/solutions/ex3/listing.kt
@@ -31,7 +31,7 @@ fun mean(): Process<Double, Double> {
 
 class Exercise3 : WordSpec({
     "mean" should {
-        "calculate a running average of values encounterd so far" {
+        "calculate a running average of values encountered so far" {
             val stream = Stream.of(1.0, 2.0, 3.0, 4.0, 5.0)
             val p = mean()
             p(stream).toList() shouldBe List.of(1.0, 1.5, 2.0, 2.5, 3.0)

--- a/src/test/kotlin/chapter15/solutions/ex5/listing.kt
+++ b/src/test/kotlin/chapter15/solutions/ex5/listing.kt
@@ -35,10 +35,8 @@ fun product(): Process<Double, Double> {
     fun go(acc: Double): Process<Double, Double> =
         Await { i: Option<Double> ->
             when (i) {
-                is Some -> if (i.get == 0.0)
-                    Emit (0.0)
-                else
-                    Emit(i.get * acc, go(i.get * acc))
+                is Some -> if (i.get == 0.0) Emit(0.0)
+                    else Emit(i.get * acc, go(i.get * acc))
                 is None -> Halt<Double, Double>()
             }
         }

--- a/src/test/kotlin/chapter15/solutions/ex5/listing.kt
+++ b/src/test/kotlin/chapter15/solutions/ex5/listing.kt
@@ -35,7 +35,10 @@ fun product(): Process<Double, Double> {
     fun go(acc: Double): Process<Double, Double> =
         Await { i: Option<Double> ->
             when (i) {
-                is Some -> if (i.get == 0.0) Emit (0.0) else Emit(i.get * acc, go(i.get * acc))
+                is Some -> if (i.get == 0.0)
+                    Emit (0.0)
+                else
+                    Emit(i.get * acc, go(i.get * acc))
                 is None -> Halt<Double, Double>()
             }
         }
@@ -58,7 +61,8 @@ class Exercise5 : WordSpec({
             val fused = incP pipe productP
             // incP: (2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0)
             // productP: (2.0, 6.0, 24.0, 120.0, 720.0, 5040.0, 40320.0)
-            fused(stream).toList() shouldBe List.of(2.0, 6.0, 24.0, 120.0, 720.0, 5040.0, 40320.0)
+            fused(stream).toList() shouldBe
+                    List.of(2.0, 6.0, 24.0, 120.0, 720.0, 5040.0, 40320.0)
         }
         "fuse together two processes (test 2 inversus)" {
             val stream = Stream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)
@@ -67,7 +71,8 @@ class Exercise5 : WordSpec({
             val fused = productP pipe incP
             // productP: (1.0, 2.0, 3.0, 24.0, 120.0, 720.0, 5040.0)
             // incP: (2.0, 3.0, 7.0, 25.0, 121.0, 721.0, 5041.0)
-            fused(stream).toList() shouldBe List.of(2.0, 3.0, 7.0, 25.0, 121.0, 721.0, 5041.0)
+            fused(stream).toList() shouldBe
+                    List.of(2.0, 3.0, 7.0, 25.0, 121.0, 721.0, 5041.0)
         }
     }
 })

--- a/src/test/kotlin/chapter15/solutions/ex5/listing.kt
+++ b/src/test/kotlin/chapter15/solutions/ex5/listing.kt
@@ -1,6 +1,7 @@
 package chapter15.solutions.ex5
 
 import chapter10.None
+import chapter10.Option
 import chapter10.Some
 import chapter15.sec2.Await
 import chapter15.sec2.Emit
@@ -8,6 +9,7 @@ import chapter15.sec2.Halt
 import chapter15.sec2.Process
 import chapter15.sec2.sum
 import chapter15.sec2.toList
+import chapter15.sec2.lift
 import chapter15.solutions.ex1.take
 import chapter3.List
 import chapter5.Stream
@@ -29,6 +31,17 @@ infix fun <I, O, O2> Process<I, O>.pipe(
     }
 //end::init[]
 
+fun product(): Process<Double, Double> {
+    fun go(acc: Double): Process<Double, Double> =
+        Await { i: Option<Double> ->
+            when (i) {
+                is Some -> if (i.get == 0.0) Emit (0.0) else Emit(i.get * acc, go(i.get * acc))
+                is None -> Halt<Double, Double>()
+            }
+        }
+    return go(1.0)
+}
+
 class Exercise5 : WordSpec({
     "pipe" should {
         "fuse together two processes" {
@@ -37,6 +50,24 @@ class Exercise5 : WordSpec({
             val take4 = take<Double>(4)
             val fused = sumP pipe take4
             fused(stream).toList() shouldBe List.of(1.0, 3.0, 6.0, 10.0)
+        }
+        "fuse together two processes (test 2 rectus)" {
+            val stream = Stream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)
+            val incP: Process<Double, Double> = lift { n: Double -> n + 1 }
+            val productP: Process<Double, Double> = product()
+            val fused = incP pipe productP
+            // incP: (2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0)
+            // productP: (2.0, 6.0, 24.0, 120.0, 720.0, 5040.0, 40320.0)
+            fused(stream).toList() shouldBe List.of(2.0, 6.0, 24.0, 120.0, 720.0, 5040.0, 40320.0)
+        }
+        "fuse together two processes (test 2 inversus)" {
+            val stream = Stream.of(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)
+            val productP: Process<Double, Double> = product()
+            val incP: Process<Double, Double> = lift { n: Double -> n + 1 }
+            val fused = productP pipe incP
+            // productP: (1.0, 2.0, 3.0, 24.0, 120.0, 720.0, 5040.0)
+            // incP: (2.0, 3.0, 7.0, 25.0, 121.0, 721.0, 5041.0)
+            fused(stream).toList() shouldBe List.of(2.0, 3.0, 7.0, 25.0, 121.0, 721.0, 5041.0)
         }
     }
 })

--- a/src/test/kotlin/chapter15/solutions/ex6/listing.kt
+++ b/src/test/kotlin/chapter15/solutions/ex6/listing.kt
@@ -58,7 +58,7 @@ class Exercise6 : WordSpec({
     }
 
     "mean" should {
-        "calculate a running average of values encounterd so far" {
+        "calculate a running average of values encountered so far" {
             val p = mean()
             p(stream).toList() shouldBe
                 List.of(1.0, 1.5, 2.0, 2.5, 3.0, 3.5)

--- a/src/test/kotlin/chapter15/solutions/ex8/listing.kt
+++ b/src/test/kotlin/chapter15/solutions/ex8/listing.kt
@@ -13,7 +13,7 @@ import chapter5.Stream
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
 
-//tag::init[]
+//tag::init1[]
 fun <I> exists(f: (I) -> Boolean): Process<I, Boolean> =
     Await { i: Option<I> ->
         when (i) {
@@ -24,8 +24,26 @@ fun <I> exists(f: (I) -> Boolean): Process<I, Boolean> =
                 )
             is None -> Halt<I, Boolean>()
         }
-    }.repeat()
-//end::init[]
+    }
+//end::init1[]
+
+//tag::init2[]
+fun <I> existsAndHalts(f: (I) -> Boolean): Process<I, Boolean> =
+    Await { i: Option<I> ->
+        when (i) {
+            is Some ->
+                if (f(i.get)) {
+                    Emit<I, Boolean>(true)
+                } else {
+                    Emit<I, Boolean>(
+                        false,
+                        existsAndHalts { f(it) }
+                    )
+                }
+            is None -> Halt<I, Boolean>()
+        }
+    }
+//end::init2[]
 
 class Exercise8 : WordSpec({
     "exists" should {
@@ -34,6 +52,12 @@ class Exercise8 : WordSpec({
             val p = exists<Int> { i -> i % 2 == 0 }
             p(stream).toList() shouldBe
                 List.of(false, false, false, true, true)
+        }
+        "halt and yield all intermediate results" {
+            val stream = Stream.of(1, 3, 5, 6, 7)
+            val p = existsAndHalts<Int> { i -> i % 2 == 0 }
+            p(stream).toList() shouldBe
+                    List.of(false, false, false, true)
         }
     }
 })


### PR DESCRIPTION
Proofed chapter 15.

src/main/kotlin/chapter15/sec2/listing.kt: I added println(units) to better reproduce the REPL-based tests depicted in the text.

src/main/kotlin/chapter15/sec3_4/listing.kt: Without this fix, the tee() function enters an infinite loop. I checked it against the Scala version.

src/main/kotlin/chapter15/sec3_5/listing.kt: We're getting into tricky stuff here...
- I needed to add fw.flush() to get some output into the generated celsius.txt file.
- I had to adjust the file paths to get the converter Process to find the fahrenheit.txt file I created to get the test to run properly.
- I created a copy of the converter to work freely without propagating my tests into the text.
- Nonetheless, the program still doesn't work properly, as it halts after the first value converted into Celsius degrees. A fix is still needed here.

src/test/kotlin/chapter15/solutions/ex1/listing.kt: I discovered a bug that made the dropWhile() function behave exactly like filter(). I enriched the test case to prove that this fix works, and it is needed for dropWhile() to work properly.

src/test/kotlin/chapter15/solutions/ex5/listing.kt: The "sum pipe take4" test case is correct but doesn't show that pipe handles its arguments in the correct order since "take4 pipe sum" gives the same result. I created another test case, non-commutative, that better shows that the handling order of pipe is correct.

src/test/kotlin/chapter15/solutions/ex8/listing.kt: I added a solution that halts after finding an item that verifies the predicate.