### PR TITLE
Update the foldRight / foldLeft test cases to catch more cases

### DIFF
--- a/src/test/kotlin/chapter3/exercises/ex12/listing.kt
+++ b/src/test/kotlin/chapter3/exercises/ex12/listing.kt
@@ -26,12 +26,32 @@ class Exercise12 : WordSpec({
         }
     }
 
+    "list strings foldLeftR" should {
+        "!implement foldLeft functionality using foldRight" {
+            foldLeftR(
+                List.of("AAA", "BBB", "CCC", "DDD"),
+                "XYZ",
+                { x: String, y: String -> "$x:$y" }) shouldBe
+                "XYZ:AAA:BBB:CCC:DDD"
+        }
+    }
+
     "list foldRightL" should {
         "!implement foldRight functionality using foldLeft" {
             foldRightL(
                 List.of(1, 2, 3, 4, 5),
                 0,
                 { x, y -> x + y }) shouldBe 15
+        }
+    }
+
+    "list strings foldRightL" should {
+        "!implement foldLeft functionality using foldRight" {
+            foldRightL(
+                List.of("AAA", "BBB", "CCC", "DDD"),
+                "XYZ",
+                { x: String, y: String -> "$x:$y" }) shouldBe
+                "AAA:BBB:CCC:DDD:XYZ"
         }
     }
 })

--- a/src/test/kotlin/chapter3/exercises/ex9/listing.kt
+++ b/src/test/kotlin/chapter3/exercises/ex9/listing.kt
@@ -22,4 +22,15 @@ class Exercise9 : WordSpec({
                 { x, y -> x + y }) shouldBe 15
         }
     }
+
+    "list strings foldLeft" should {
+        """!apply a function f builds the correct concatenated string
+            from the list""" {
+            foldLeft(
+                List.of("AAA", "BBB", "CCC", "DDD"),
+                "XYZ",
+                { x: String, y: String -> "$x:$y" }) shouldBe
+                "XYZ:AAA:BBB:CCC:DDD"
+        }
+    }
 })

--- a/src/test/kotlin/chapter3/solutions/ex12/listing.kt
+++ b/src/test/kotlin/chapter3/solutions/ex12/listing.kt
@@ -64,12 +64,32 @@ class Solution12 : WordSpec({
         }
     }
 
+    "list strings foldLeftR" should {
+        "implement foldLeft functionality using foldRight" {
+            foldLeftR(
+                List.of("AAA", "BBB", "CCC", "DDD"),
+                "XYZ",
+                { x: String, y: String -> "$x:$y" }) shouldBe
+                "XYZ:AAA:BBB:CCC:DDD"
+        }
+    }
+
     "list foldRightL" should {
         "implement foldRight functionality using foldLeft" {
             foldRightL(
                 List.of(1, 2, 3, 4, 5),
                 0,
                 { x, y -> x + y }) shouldBe 15
+        }
+    }
+
+    "list strings foldRightL" should {
+        "implement foldLeft functionality using foldRight" {
+            foldRightL(
+                List.of("AAA", "BBB", "CCC", "DDD"),
+                "XYZ",
+                { x: String, y: String -> "$x:$y" }) shouldBe
+                "AAA:BBB:CCC:DDD:XYZ"
         }
     }
 })

--- a/src/test/kotlin/chapter3/solutions/ex9/listing.kt
+++ b/src/test/kotlin/chapter3/solutions/ex9/listing.kt
@@ -24,4 +24,15 @@ class Solution9 : WordSpec({
                     { x, y -> x + y }) shouldBe 15
             }
     }
+
+    "list strings foldLeft" should {
+        """apply a function f builds the correct concatenated string from
+            the list""" {
+            foldLeft(
+                List.of("AAA", "BBB", "CCC", "DDD"),
+                "XYZ",
+                { x: String, y: String -> "$x:$y" }) shouldBe
+                "XYZ:AAA:BBB:CCC:DDD"
+        }
+    }
 })


### PR DESCRIPTION
This PR Adds test cases that are based on the order of calculation to make sure that the calculation is actually done correctly.

I've noticed that my 1st naive implementation of ex3.12 did not failed by any tests (see code):

```kotlin
fun <A, B> foldLeftR(xs: List<A>, z: B, f: (B, A) -> B): B =
    foldRight(xs, z) { x, y -> f(y, x) }

fun <A, B> foldRightL(xs: List<A>, z: B, f: (A, B) -> B): B =
    foldLeft(xs, z) { x, y -> f(y, x) }
```

The reason it didn't fail is that for the calculation of sum the order has no effect on the result, however by adding string the format of the string would be directly impacted by the order.

Originally I've added this only to ex3.12 - but as the same basically goes for all `foldRight` and `foldLeft` implementations I've decided to add it to them as well