### PR TITLE
fix bug in exercise 5.5 - takeWhile not terminating properly

### DIFF
--- a/src/test/kotlin/chapter5/exercises/ex3/listing.kt
+++ b/src/test/kotlin/chapter5/exercises/ex3/listing.kt
@@ -22,6 +22,11 @@ class Exercise3 : WordSpec({
             s.takeWhile { it < 4 }.toList() shouldBe
                 List.of(1, 2, 3)
         }
+        "!stop returning once predicate evaluates false" {
+            val s = Stream.of(1, 2, 3, 4, 5, 4, 3, 2, 1)
+            s.takeWhile { it < 4 }.toList() shouldBe
+                List.of(1, 2, 3)
+        }
         "!return all elements if predicate always evaluates true" {
             val s = Stream.of(1, 2, 3, 4, 5)
             s.takeWhile { true }.toList() shouldBe

--- a/src/test/kotlin/chapter5/exercises/ex5/listing.kt
+++ b/src/test/kotlin/chapter5/exercises/ex5/listing.kt
@@ -22,6 +22,11 @@ class Exercise5 : WordSpec({
             s.takeWhile { it < 4 }.toList() shouldBe
                 List.of(1, 2, 3)
         }
+        "!stop returning once predicate evaluates false" {
+            val s = Stream.of(1, 2, 3, 4, 5, 4, 3, 2, 1)
+            s.takeWhile { it < 4 }.toList() shouldBe
+                List.of(1, 2, 3)
+        }
         "!return all elements if predicate always evaluates true" {
             val s = Stream.of(1, 2, 3, 4, 5)
             s.takeWhile { true }.toList() shouldBe

--- a/src/test/kotlin/chapter5/solutions/ex3/listing.kt
+++ b/src/test/kotlin/chapter5/solutions/ex3/listing.kt
@@ -29,6 +29,11 @@ class Solution3 : WordSpec({
             s.takeWhile { it < 4 }.toList() shouldBe
                 List.of(1, 2, 3)
         }
+        "stop returning once predicate evaluates false" {
+            val s = Stream.of(1, 2, 3, 4, 5, 4, 3, 2, 1)
+            s.takeWhile { it < 4 }.toList() shouldBe
+                List.of(1, 2, 3)
+        }
         "return all elements if predicate always evaluates true" {
             val s = Stream.of(1, 2, 3, 4, 5)
             s.takeWhile { true }.toList() shouldBe

--- a/src/test/kotlin/chapter5/solutions/ex5/listing.kt
+++ b/src/test/kotlin/chapter5/solutions/ex5/listing.kt
@@ -13,12 +13,17 @@ class Solution5 : WordSpec({
     //tag::init[]
     fun <A> Stream<A>.takeWhile(p: (A) -> Boolean): Stream<A> =
         foldRight({ empty() },
-            { h, t -> if (p(h)) cons({ h }, t) else t() })
+            { h, t -> if (p(h)) cons({ h }, t) else empty() })
     //end::init[]
 
     "Stream.takeWhile" should {
         "return elements while the predicate evaluates true" {
             val s = Stream.of(1, 2, 3, 4, 5)
+            s.takeWhile { it < 4 }.toList() shouldBe
+                List.of(1, 2, 3)
+        }
+        "stop returning once predicate evaluates false" {
+            val s = Stream.of(1, 2, 3, 4, 5, 4, 3, 2, 1)
             s.takeWhile { it < 4 }.toList() shouldBe
                 List.of(1, 2, 3)
         }


### PR DESCRIPTION
Hi!

I think I've spotted a bug in the implementation of Stream.takeWhile for the solutions to exercise 5.5. 

The current implementation acts more like a filter than a takeWhile -  it will return _all_ elements where the predicate returns true, even those seen after the predicate has already returned false.

I've modified the solution to return empty instead of the tail when the predicate is false, which I think is the correct behaviour, and added a test to cover the bug. I've also copied the new test over to ex 5.3, which didn't have this bug, but others may find it useful when writing their own solutions.

Thanks!