### PR TITLE
ex5.13 implement Stream.take in terms of unfold without taking recursively

### DIFF
--- a/src/test/kotlin/chapter5/solutions/ex13/listing.kt
+++ b/src/test/kotlin/chapter5/solutions/ex13/listing.kt
@@ -23,11 +23,11 @@ fun <A, B> Stream<A>.map(f: (A) -> B): Stream<B> =
 
 //tag::take[]
 fun <A> Stream<A>.take(n: Int): Stream<A> =
-    Stream.unfold(this) { s: Stream<A> ->
+    Stream.unfold(this to n) { (s: Stream<A>, m: Int) ->
         when (s) {
             is Cons ->
-                if (n > 0)
-                    Some(s.head() to s.tail().take(n - 1))
+                if (m > 0)
+                    Some(s.head() to (s.tail() to m - 1))
                 else None
             else -> None
         }


### PR DESCRIPTION
I think there may be an issue with how the solution to `Stream.take(n)` is implemented for exercise 5.13.

The current solution calls `take` recursively on the tail, which I think somewhat defeats the point of defining it in terms of `unfold`, and causes a large number of redundant evaluations of unfold's lambda `f`. Not sure what the complexity of this is exactly but I would've assumed the solution would ideally be linear in the size of the stream.

With the current solution, `Stream.of(1,2,3,4,5).take(5)` makes the following calls to `f`:

<details> 
  <summary>Expand</summary>

   ```
s:[1,2,3,4,5]  n: 5
s:  [2,3,4,5]  n: 4
s:    [3,4,5]  n: 3
s:      [4,5]  n: 2
s:        [5]  n: 1
s:         []  n: 0
s:         []  n: 1
s:        [5]  n: 2
s:         []  n: 1
s:         []  n: 2
s:      [4,5]  n: 3
s:        [5]  n: 2
s:         []  n: 1
s:         []  n: 2
s:        [5]  n: 3
s:         []  n: 2
s:         []  n: 3
s:    [3,4,5]  n: 4
s:      [4,5]  n: 3
s:        [5]  n: 2
s:         []  n: 1
s:         []  n: 2
s:        [5]  n: 3
s:         []  n: 2
s:         []  n: 3
s:      [4,5]  n: 4
s:        [5]  n: 3
s:         []  n: 2
s:         []  n: 3
s:        [5]  n: 4
s:         []  n: 3
s:         []  n: 4
s:  [2,3,4,5]  n: 5
s:    [3,4,5]  n: 4
s:      [4,5]  n: 3
s:        [5]  n: 2
s:         []  n: 1
s:         []  n: 2
s:        [5]  n: 3
s:         []  n: 2
s:         []  n: 3
s:      [4,5]  n: 4
s:        [5]  n: 3
s:         []  n: 2
s:         []  n: 3
s:        [5]  n: 4
s:         []  n: 3
s:         []  n: 4
s:    [3,4,5]  n: 5
s:      [4,5]  n: 4
s:        [5]  n: 3
s:         []  n: 2
s:         []  n: 3
s:        [5]  n: 4
s:         []  n: 3
s:         []  n: 4
s:      [4,5]  n: 5
s:        [5]  n: 4
s:         []  n: 3
s:         []  n: 4
s:        [5]  n: 5
s:         []  n: 4
s:         []  n: 5
```
</details>

The solution I've proposed instead includes the number of items left to take, `m`, as part of `unfold`'s state. This solution makes |s| + 1 calls to `f` and, I think, is more in the spirit of the question's original intentions.

<details> 
  <summary>Expand</summary>

   ```
s:[1,2,3,4,5]  m: 5
s:  [2,3,4,5]  m: 4
s:    [3,4,5]  m: 3
s:      [4,5]  m: 2
s:        [5]  m: 1
s:         []  m: 0
```
</details>

Thanks!
