### PR TITLE
fix exercise 5.15 solution to include empty list as the final value

### DIFF
--- a/src/test/kotlin/chapter5/solutions/ex15/listing.kt
+++ b/src/test/kotlin/chapter5/solutions/ex15/listing.kt
@@ -4,7 +4,9 @@ import chapter3.List
 import chapter4.None
 import chapter4.Some
 import chapter5.Cons
+import chapter5.Empty
 import chapter5.Stream
+import chapter5.solutions.ex7.append
 import chapter5.toList
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
@@ -21,7 +23,7 @@ class Solution15 : WordSpec({
                     Some(s to s.tail())
                 else -> None
             }
-        }
+        }.append { Stream.of(Empty) }
     //end::tails[]
 
     fun <A, B> List<A>.map(f: (A) -> B): List<B> = when (this) {
@@ -36,7 +38,8 @@ class Solution15 : WordSpec({
                 List.of(
                     ConsL(1, ConsL(2, ConsL(3, NilL))),
                     ConsL(2, ConsL(3, NilL)),
-                    ConsL(3, NilL)
+                    ConsL(3, NilL),
+                    NilL
                 )
         }
     }


### PR DESCRIPTION
Spotted a bit of an inconsistency between the solution to ex 5.15 and its description/tests.

The description in the book reads 

> For example, given `Stream.of(1,2,3)` , it would return `Stream.of(Stream.of(1,2,3), Stream.of(2,3), Stream.of(3), Stream.empty())`

 and that's what the tests in the exercises section assert.

The solution provided doesn't seem to return that final `Stream.empty()` though, and the tests in that file don't assert it either. 

Assuming that tails actually _should_ return the empty stream, I've modified the solution to just append it at the end, and changed the test to assert that too.

If tails shouldn't include the empty stream, you'll probably want to modify the description in the book and change the test in the exercises section instead.

Thanks!